### PR TITLE
RDKTV-9120 : No Xcast post FTUE

### DIFF
--- a/server/plat/scripts/startXdial.sh
+++ b/server/plat/scripts/startXdial.sh
@@ -92,7 +92,12 @@ Manufacturer=$MFG_NAME
 echo "Manufacturer: $Manufacturer"
 #Get UUID
 UUID=$(getReceiverId)
+if [ -z "$UUID" ]; then
+    #Assigning default UUID
+    UUID="12345678-abcd-abcd-1234-123456789abc"
+fi
 echo "UUID: $UUID"
+
 
 #Opening Required PORTS
 XDIAL_IFNAME=$(getESTBInterfaceName)


### PR DESCRIPTION
Reason for change:
No Xcast post FTUE
Test Procedure: None
Risks: Low

Change-Id: If4453978c4a1f2836052a75c254302af876da5ec
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>