### PR TITLE
RDKTV-9120 : No Xcast post FTUE

### DIFF
--- a/server/plat/scripts/startXdial.sh
+++ b/server/plat/scripts/startXdial.sh
@@ -92,6 +92,10 @@ Manufacturer=$MFG_NAME
 echo "Manufacturer: $Manufacturer"
 #Get UUID
 UUID=$(getReceiverId)
+if [ -z "$UUID" ]; then
+    #Assigning default UUID
+    UUID="12345678-abcd-abcd-1234-123456789abc"
+fi
 echo "UUID: $UUID"
 
 #Opening Required PORTS


### PR DESCRIPTION
Reason for change:
No Xcast post FTUE
Test Procedure: None
Risks: Low

Change-Id: I9fb7be9431d29246ae9397c901f92307f87fe3e1
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>