### PR TITLE
RDKTV-6424:DIAL feature is not supported for YT TV App

### DIFF
--- a/server/gdial-rest.c
+++ b/server/gdial-rest.c
@@ -429,7 +429,7 @@ static void gdial_rest_server_handle_POST(GDialRestServer *gdial_rest_server, So
     const gchar *payload = msg->request_body->data;
     gchar *payload_safe = NULL;
     if (payload && strlen(payload)) {
-      if (g_strcmp0(app->name, "YouTube") == 0) {
+      if (g_str_has_prefix(app->name, "YouTube")) {
         /* temporary disabling encoding payload for YouTube till cloud side changed*/
         payload_safe = g_strdup(payload);
       }

--- a/server/main.c
+++ b/server/main.c
@@ -257,6 +257,16 @@ int main(int argc, char *argv[]) {
       g_print("youtube is not enabled from cmdline\r\n");
     }
 
+    if (g_strstr_len(app_list_low, app_list_len, "youtubetv")) {
+      g_print("youtubetv is enabled from cmdline\r\n");
+      GList *allowed_origins = g_list_prepend(NULL, ".youtube.com");
+      gdial_rest_server_register_app(dial_rest_server, "YouTubeTV", NULL, NULL, TRUE, TRUE, allowed_origins);
+      g_list_free(allowed_origins);
+    }
+    else {
+      g_print("youtubetv is not enabled from cmdline\r\n");
+    }
+
     if (g_strstr_len(app_list_low, app_list_len, "amazoninstantvideo")) {
       g_print("AmazonInstantVideo is enabled from cmdline\r\n");
       GList *allowed_origins = g_list_prepend(NULL, ".amazonprime.com");


### PR DESCRIPTION
Reason for change: Added YTTV app support
Test Procedure: Refer JIRA.
Risks: Low

Signed-off-by: apatel859 <amit_patel5@comcast.com>