### PR TITLE
RDKDEV-168: Refactor ever running parent scripts which take up memory.

### DIFF
--- a/server/plat/scripts/startXdial.sh
+++ b/server/plat/scripts/startXdial.sh
@@ -199,7 +199,7 @@ if tr181Set -g Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.XDial.Enable 2>&1 
     AppList_OPTION=$(getCmdlineOption "-A" "$AppList")
 
     echo "gdial-server args: ${XDIAL_IFNAME_OPTION} ${FriendlyName_OPTION} ${Manufacturer_OPTION} ${ModelName_OPTION} ${UUID_OPTION} ${AppList_OPTION} ${XDIAL_FRIENDLYNAME_ENABLED} ${XDIAL_WOLWAKE_ENABLED}"
-    /usr/share/xdial/gdial-server ${XDIAL_IFNAME_OPTION} ${FriendlyName_OPTION} ${Manufacturer_OPTION} ${ModelName_OPTION} ${UUID_OPTION} ${AppList_OPTION} ${XDIAL_FRIENDLYNAME_ENABLED} ${XDIAL_WOLWAKE_ENABLED}
+    exec /usr/share/xdial/gdial-server ${XDIAL_IFNAME_OPTION} ${FriendlyName_OPTION} ${Manufacturer_OPTION} ${ModelName_OPTION} ${UUID_OPTION} ${AppList_OPTION} ${XDIAL_FRIENDLYNAME_ENABLED} ${XDIAL_WOLWAKE_ENABLED}
 else
     echo "rfc disabled: gdial-server not started"
 fi


### PR DESCRIPTION
RDKDEV-168: Refactor ever running parent scripts which take up memory.
Reason for change: Refactor ever-running parent script startXdial.sh. which doesn't get exited after spawning gdial-server.
Test Procedure: Refer RDK wiki.
Risks: Low
Signed-off-by: fasil kv <fasil_KV@comcast.com>