### PR TITLE
RDKTV-10986 RDKTV-11484: DeviceName not listed for casting

### DIFF
--- a/server/plat/gdial-plat-dev.c
+++ b/server/plat/gdial-plat-dev.c
@@ -24,6 +24,7 @@
 
 IARM_Bus_PWRMgr_PowerState_t m_powerstate = IARM_BUS_PWRMGR_POWERSTATE_STANDBY;
 static int m_sleeptime = 1;
+static bool m_is_restart_req = false;
 
 const char * gdial_plat_dev_get_manufacturer() {
   return g_getenv("GDIAL_DEV_MANUFACTURER");
@@ -40,9 +41,16 @@ void gdial_plat_dev_power_mode_change(const char *owner, IARM_EventId_t eventId,
     m_powerstate = param->data.state.newState;
     if(m_powerstate == IARM_BUS_PWRMGR_POWERSTATE_ON) {
       m_sleeptime = 1;
+      if (m_is_restart_req) {
+        //xdial restart to work in deepsleep wakeup
+        system("systemctl restart xdial.service");
+        m_is_restart_req = false;
+      }
     }
     else if(m_powerstate == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_DEEP_SLEEP) {
       m_sleeptime = 3;
+      //After DEEPSLEEP, restart xdial again for next transition.
+      m_is_restart_req = true;
     }
     printf("gdial_plat_dev_power_mode_change new power state: %d m_sleeptime:%d \n ",m_powerstate,m_sleeptime );
   }


### PR DESCRIPTION
Reason for change:
DeviceName not listed for casting
Test Procedure: None
Risks: Low

Change-Id: Id2e88b32ed4079e7bc4388b8c425e9975a6e8b9b
Signed-off-by: Anooj Cheriyan <Anooj_Cheriyan@comcast.com>