### PR TITLE
SERXIONE-244: dial support for YouTube kids

### DIFF
--- a/server/main.c
+++ b/server/main.c
@@ -267,6 +267,16 @@ int main(int argc, char *argv[]) {
       g_print("youtubetv is not enabled from cmdline\r\n");
     }
 
+    if (g_strstr_len(app_list_low, app_list_len, "youtubekids")) {
+      g_print("youtubekids is enabled from cmdline\r\n");
+      GList *allowed_origins = g_list_prepend(NULL, ".youtube.com");
+      gdial_rest_server_register_app(dial_rest_server, "YouTubeKids", NULL, NULL, TRUE, TRUE, allowed_origins);
+      g_list_free(allowed_origins);
+    }
+    else {
+      g_print("youtubekids is not enabled from cmdline\r\n");
+    }
+
     if (g_strstr_len(app_list_low, app_list_len, "amazoninstantvideo")) {
       g_print("AmazonInstantVideo is enabled from cmdline\r\n");
       GList *allowed_origins = g_list_prepend(NULL, ".amazonprime.com");


### PR DESCRIPTION
Reason for change:  added dial support for YT kids
Test Procedure: refer jira.
Risks: Low

Signed-off-by: apatel859 <amit_patel5@comcast.com>