### PR TITLE
RDKTV-18755: Hisense Manufacturer name as xglobal

### DIFF
--- a/server/plat/scripts/startXdial.sh
+++ b/server/plat/scripts/startXdial.sh
@@ -93,12 +93,17 @@ if [ $expValue = "Flex" ]; then
     echo "Flex experience ModelName:$ModelName"
 fi
 
+if [ $RDK_PROFILE = "TV" ]; then
+  Manufacturer=$MFG_NAME
+else
+  Manufacturer=$PartnerId
+fi
+echo "Manufacturer: $Manufacturer"
+
 #Construct Friendly Name for Netflix
-FriendlyName=`echo "${PartnerId}_${ModelName}"`
+FriendlyName=`echo "${Manufacturer}_${ModelName}"`
 echo "Friendly Name: $FriendlyName"
 
-Manufacturer=$PartnerId
-echo "Manufacturer: $Manufacturer"
 #Get UUID
 UUID=$(getReceiverId)
 echo "UUID: $UUID"


### PR DESCRIPTION
Reason for change:  Fix manufacturing name for TV profile
Test Procedure: refer jira.
Risks: Low

Signed-off-by: apatel859 <amit_patel5@comcast.com>
(cherry picked from commit 20921ec5328465a6777196865030255ce2a9a961)