### PR TITLE
RDK-35406 : XCAST unregisterApplications API

### DIFF
--- a/server/plat/rtdial.cpp
+++ b/server/plat/rtdial.cpp
@@ -179,7 +179,7 @@ public:
            }
        }
        int appListSize = g_list_length (gAppList);
-       if( g_registerapps_cb && appListSize) {
+       if( g_registerapps_cb ) {
            printf("RTDIAL: rtDialCastRemoteObject:: calling register_applications callback \n");
            g_registerapps_cb(gAppList);
        }


### PR DESCRIPTION
Reason for change:
XCAST unregisterApplications API
Test Procedure: None
Risks: Low

Change-Id: I8f2fcd056dbd29ee54850e6baac43c557ba2f208 Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>