### PR TITLE
RDKDEV-654 RDKCOM-3562 Key protection for DIAL system sleep request

### DIFF
--- a/server/gdial-app.c
+++ b/server/gdial-app.c
@@ -195,7 +195,7 @@ GDialAppError gdial_app_start(GDialApp *app, const gchar *payload, const gchar *
   GDialAppPrivate *priv = gdial_app_get_instance_private(app);
   priv->state_cb_data = state_cb_data;
   GDialAppError app_err = gdial_plat_application_start(app->name, payload, query, additional_data_url, &app->instance_id);
-  if (app_err == GDIAL_APP_ERROR_NONE || app->instance_id != GDIAL_APP_INSTANCE_NONE) {
+  if (app_err == GDIAL_APP_ERROR_NONE || (strcmp("system", app->name) != 0 && app->instance_id != GDIAL_APP_INSTANCE_NONE)) {
     gdial_plat_application_state_async(app->name, app->instance_id, app);
     app_err = gdial_plat_application_state(app->name, app->instance_id, &app->state);
     g_warn_if_fail(app->state == GDIAL_APP_STATE_RUNNING);
@@ -203,6 +203,7 @@ GDialAppError gdial_app_start(GDialApp *app, const gchar *payload, const gchar *
   else {
     app->state = GDIAL_APP_STATE_STOPPED;
   }
+
   return app_err;
 }
 


### PR DESCRIPTION
RDKDEV-654 RDKCOM-3562 Key protection for DIAL system sleep request
Custom key can be used to protect
'system?action=sleep'
requests (as specified in Dial 2.2, system sleep request) The key value can be passed via SYSTEM_SLEEP_REQUEST_KEY env var; if not defined - will not be validated
Signed-off-by: tomasz-karczewski-red <tkarczewski.contractor@libertyglobal.com>

(cherry picked from commit 4cea95aec9af1d4ed8963166b3512dce8887134e) (cherry picked from commit 19ee7a7b39c33c489e41227f83c48cc5832b53cc)