### PR TITLE
Omwappi 1545 xdial server patches 2401 sprint

### DIFF
--- a/server/plat/rtcache.hpp
+++ b/server/plat/rtcache.hpp
@@ -28,11 +28,19 @@
 #include <chrono>
 #include <stdbool.h>
 
+#include <functional>
+#include <mutex>
+#include <map>
+
 using namespace std;
 
 class rtAppStatusCache : public rtObject
 {
 public:
+
+    using StateChangedCallbackHandle = size_t;
+    using StateChangedCallback = std::function<void(const std::string&)>;
+
     rtAppStatusCache(rtRemoteEnvironment* env) {ObjectCache = new rtRemoteObjectCache(env);};
     ~rtAppStatusCache() {delete(ObjectCache); };
     std::string getAppCacheId(const char *app_name);
@@ -41,10 +49,19 @@ public:
     const char * SearchAppStatusInCache(const char *app_name);
     bool doIdExist(std::string id);
 
+    StateChangedCallbackHandle registerStateChangedCallback(StateChangedCallback callback);
+    void unregisterStateChangedCallback(StateChangedCallbackHandle callbackId);
+
 private:
+
+    void notifyStateChanged(std::string& id);
+
     rtRemoteObjectCache* ObjectCache;
     static std::string Netflix_AppCacheId;
     static std::string Youtube_AppCacheId;
+    StateChangedCallbackHandle next_handle = 0;
+    std::map<StateChangedCallbackHandle, StateChangedCallback> state_changed_listeners;
+    std::mutex state_changed_listeners_mutex;
 };
 
 #endif

--- a/server/plat/rtcache.hpp
+++ b/server/plat/rtcache.hpp
@@ -52,6 +52,8 @@ public:
     StateChangedCallbackHandle registerStateChangedCallback(StateChangedCallback callback);
     void unregisterStateChangedCallback(StateChangedCallbackHandle callbackId);
 
+    std::chrono::milliseconds getUpdateAge(const char *app_name);
+
 private:
 
     void notifyStateChanged(std::string& id);
@@ -62,6 +64,7 @@ private:
     StateChangedCallbackHandle next_handle = 0;
     std::map<StateChangedCallbackHandle, StateChangedCallback> state_changed_listeners;
     std::mutex state_changed_listeners_mutex;
+    std::map<std::string, std::chrono::steady_clock::time_point> last_updated;
 };
 
 #endif

--- a/server/plat/rtdial.cpp
+++ b/server/plat/rtdial.cpp
@@ -22,6 +22,7 @@
 #include <map>
 #include <unistd.h>
 #include <pthread.h>
+#include <atomic>
 #include <glib.h>
 
 #include "Module.h"
@@ -40,6 +41,7 @@
 #include "rtcache.hpp"
 #include "rtdial.hpp"
 #include "gdial_app_registry.h"
+#include <rtRemoteEnvironment.h>
 
 rtRemoteEnvironment* env;
 static GSource *remoteSource = nullptr;
@@ -450,6 +452,8 @@ void rtdial_term() {
 
 #define DIAL_MAX_ADDITIONALURL (1024)
 
+static bool await_application_state_update(const char *app_name);
+
 map<string,string> parse_query(const char* query_string) {
     if (!query_string) return {};
     char *unescaped = g_uri_unescape_string(query_string, nullptr);
@@ -659,6 +663,10 @@ int gdial_os_application_state(const char *app_name, int instance_id, GDialAppSt
         if (RTCAST_ERROR_RT(ret) != RT_OK) {
             printf("RTDIAL: DialObj.getApplicationState failed!!! Error: %s\n",rtStrError(RTCAST_ERROR_RT(ret)));
             return GDIAL_APP_ERROR_INTERNAL;
+        } else {
+            if (await_application_state_update(app_name)) {
+                State = AppCache->SearchAppStatusInCache(app_name);
+            }
         }
     }
 
@@ -693,4 +701,33 @@ int gdial_os_application_state(const char *app_name, int instance_id, GDialAppSt
     }
 
     return GDIAL_APP_ERROR_NONE;
+}
+
+static bool await_application_state_update(const char *app_name) {
+    static int xdial_wait_for_rtremote_state_response_ms = -1;
+    if (xdial_wait_for_rtremote_state_response_ms == -1) {
+        const char* waitstr = getenv("XDIAL_WAIT_FOR_RTREMOTE_STATE_RESPONSE_MS");
+        xdial_wait_for_rtremote_state_response_ms = waitstr ? atoi(waitstr) : 0;
+    }
+    std::atomic_bool updated {false};
+    if (xdial_wait_for_rtremote_state_response_ms > 0) {
+        // the cached status could be wrong; rtremote state update request has already been launched
+        // so lets give it some time & report the updated value, if possible
+        using namespace std::chrono;
+
+        auto handlerid = AppCache->registerStateChangedCallback([&](const std::string& application){
+            if (application == app_name) {
+                updated = true;
+            }
+        });
+        const auto timemax = steady_clock::now() + milliseconds(xdial_wait_for_rtremote_state_response_ms);
+        while (steady_clock::now() < timemax && !updated) {
+            auto time_left = duration_cast<milliseconds>(timemax - steady_clock::now());
+            if (time_left.count() > 0) {
+                rtEnvironmentGetGlobal()->processSingleWorkItem(time_left, true, nullptr);
+            }
+        }
+        AppCache->unregisterStateChangedCallback(handlerid);
+    }
+    return updated;
 }

--- a/server/plat/rtdial.cpp
+++ b/server/plat/rtdial.cpp
@@ -704,17 +704,25 @@ int gdial_os_application_state(const char *app_name, int instance_id, GDialAppSt
 }
 
 static bool await_application_state_update(const char *app_name) {
+    using namespace std::chrono;
     static int xdial_wait_for_rtremote_state_response_ms = -1;
     if (xdial_wait_for_rtremote_state_response_ms == -1) {
         const char* waitstr = getenv("XDIAL_WAIT_FOR_RTREMOTE_STATE_RESPONSE_MS");
         xdial_wait_for_rtremote_state_response_ms = waitstr ? atoi(waitstr) : 0;
     }
+    static auto xdial_max_state_value_age = milliseconds::max();
+    if (xdial_max_state_value_age == milliseconds::max()) {
+        const char* str = getenv("XDIAL_MAX_STATE_VALUE_AGE_MS");
+        xdial_max_state_value_age = milliseconds(str ? atoi(str) : 0);
+    }
+    // do not poll for the state update if currently held value is younger than XDIAL_MAX_STATE_VALUE_AGE_MS
+    if (xdial_max_state_value_age > milliseconds(0) && AppCache->getUpdateAge(app_name) < xdial_max_state_value_age) {
+        return false;
+    }
     std::atomic_bool updated {false};
     if (xdial_wait_for_rtremote_state_response_ms > 0) {
         // the cached status could be wrong; rtremote state update request has already been launched
         // so lets give it some time & report the updated value, if possible
-        using namespace std::chrono;
-
         auto handlerid = AppCache->registerStateChangedCallback([&](const std::string& application){
             if (application == app_name) {
                 updated = true;


### PR DESCRIPTION
1)ARRISAPP-69 wait for application state responses (https://github.com/LibertyGlobal/onemw-xdialserver/pull/16)

It is now possible to specify the amount of time
xdial server waits for rtremote status update resposes
with XDIAL_WAIT_FOR_RTREMOTE_STATE_RESPONSE_MS.
This can be used to make sure that up-to-date application
states are returned (instead of cached ones)

2)OMWAPPI-1342 xdial: create GDialApp if app exists (https://github.com/LibertyGlobal/onemw-xdialserver/pull/23)

if app instances are created outside of xdial, we might
still be missing GDialApp instance.
do not fetch app state asynchronously in case
xdial is configured to wait for remote state responses
anyway
if current app state is 'stopped' or 'hidden'
always return 201 on POST requests
3)OMWAPPI-1360 introduce XDIAL_MAX_STATE_VALUE_AGE_MS (https://github.com/LibertyGlobal/onemw-xdialserver/pull/24)

To limit synchronous app state polling (that takes time),
XDIAL_MAX_STATE_VALUE_AGE_MS env variable can be set to
specify how long the last state update is still
considered 'current'; until this time passes the last
cached state is returned and the remote state is not queried.

ONEMPERS-642: stop and hide results with 404 fixed (https://github.com/rdkcentral/xdialserver/pull/17)(rtcache.cpp)
cache objects marked as markUnevictable(, true) to not remove them from cache