### PR TITLE
RDK-55044: Implement DIAL requirement to use on EU product

### DIFF
--- a/server/gdial-rest.c
+++ b/server/gdial-rest.c
@@ -159,7 +159,7 @@ static GList *gdial_rest_server_registered_apps_clear(GDialRestServer *self, GLi
   GDialRestServerPrivate *priv = gdial_rest_server_get_instance_private(self);
   GDialAppRegistry *app_registry = (GDialAppRegistry *)found->data;
   registered_apps = g_list_remove_link(registered_apps, found);
-  GDIAL_LOGINFO("Removing handler for app[%s]", app_registry->name);
+  GDIAL_LOGINFO("gdial_local_rest_http_server_callback handler Removed for App[%s]instance[%x]", app_registry->name,priv->local_soup_instance);
   soup_server_remove_handler(priv->local_soup_instance, app_registry->app_uri);
   gdial_app_regstry_dispose (app_registry);
   g_list_free(found);
@@ -211,6 +211,14 @@ static gint GCompareFunc_match_registry_app_name(gconstpointer a, gconstpointer 
   return is_matched ? 0 : 1;
 }
 
+static gint GCompareFunc_match_registry_app_uuid(gconstpointer a, gconstpointer b) {
+    GDialAppRegistry *app_registry = (GDialAppRegistry *)a;
+    int is_matched = 0;
+    /* match by exact uuid */
+    is_matched = (g_strcmp0(&app_registry->app_uri[1], b) == 0);
+    return is_matched ? 0 : 1;
+}
+
 GDIAL_STATIC GDialAppRegistry *gdial_rest_server_find_app_registry(GDialRestServer *self, const gchar *app_name) {
   g_return_val_if_fail(self != NULL && app_name != NULL, FALSE);
   GDialRestServerPrivate *priv = gdial_rest_server_get_instance_private(self);
@@ -220,6 +228,16 @@ GDIAL_STATIC GDialAppRegistry *gdial_rest_server_find_app_registry(GDialRestServ
   }
   return NULL;
 }
+
+GDIAL_STATIC GDialAppRegistry *gdial_rest_server_find_app_registry_by_uuid(GDialRestServer *self, const gchar *app_uuid) {
+    g_return_val_if_fail(self != NULL && app_uuid != NULL, FALSE);
+    GDialRestServerPrivate *priv = gdial_rest_server_get_instance_private(self);
+    GList *found = g_list_find_custom(priv->registered_apps, app_uuid, GCompareFunc_match_registry_app_uuid);
+    if (found) {
+      return (GDialAppRegistry *)found->data;
+    }
+    return NULL;
+  }
 
 GDIAL_STATIC gboolean gdial_rest_server_is_allowed_youtube_origin(GDialRestServer *self, const gchar *header_origin, const gchar *app_name) {
   if (self == NULL) return FALSE;
@@ -676,13 +694,12 @@ static void gdial_local_rest_http_server_callback(SoupServer *server,
             SoupMessage *msg, const gchar *path, GHashTable *query,
             SoupClientContext  *client, gpointer user_data) {
   gchar *remote_address_str = g_inet_address_to_string(g_inet_socket_address_get_address(G_INET_SOCKET_ADDRESS(soup_client_context_get_remote_address(client))));
-  g_print_with_timestamp("gdial_local_rest_http_server_callback() %s path=%s recv from [%s], in thread %lx", msg->method, path, remote_address_str, pthread_self());
+  GDIAL_LOGINFO("method[%s] path[%s] recv from [%s], in thread %lx", msg->method, path, remote_address_str, pthread_self());
   g_free(remote_address_str);
   GDialRestServer *gdial_rest_server = (GDIAL_REST_SERVER(user_data));
-  gchar **elements = g_strsplit(&path[1], "/", 4);
+  gchar **elements = g_strsplit(&path[1], "/", 3);
   gdial_rest_server_http_return_if_fail(elements != NULL, msg, SOUP_STATUS_NOT_IMPLEMENTED);
   gchar base[GDIAL_REST_HTTP_PATH_COMPONENT_MAX_LEN] = {0};
-  gchar app_name[GDIAL_REST_HTTP_PATH_COMPONENT_MAX_LEN] = {0};
   gchar instance[GDIAL_REST_HTTP_PATH_COMPONENT_MAX_LEN] = {0};
   gchar last_elem[GDIAL_REST_HTTP_PATH_COMPONENT_MAX_LEN] = {0};
   int i = 0;
@@ -694,37 +711,35 @@ static void gdial_local_rest_http_server_callback(SoupServer *server,
       GDIAL_LOGWARNING("Warn: empty elements in URI path");
       continue;
     }
-    if (j == 0) g_strlcpy(base, elements[i], sizeof(base));
-    else if (j == 1) {
-        ret = g_strlcpy(app_name, elements[i], sizeof(app_name));
-        if (ret >= sizeof(app_name)) {
-          g_printerr("Warn: app_name too long\r\n");
-        }
+    if (j == 0) {
+        g_strlcpy(base, elements[i], sizeof(base));
     }
-    else if (j == 2) {
+    else if (j == 1) {
         ret = g_strlcpy(instance, elements[i], sizeof(instance));
         if (ret >= sizeof(instance)) {
-          g_printerr("Warn: instance too long\r\n");
+            GDIAL_LOGERROR("Warn: instance too long");
         }
     }
     ret = g_strlcpy(last_elem, elements[i], sizeof(last_elem));
     if (ret >= sizeof(last_elem)) {
-      g_printerr("Warn: last_elem too long\r\n");
+        GDIAL_LOGERROR("Warn: last_elem too long");
     }
+    GDIAL_LOGINFO("last_elem[%s]", last_elem);
     j++;
   }
   g_strfreev(elements);
   const int element_num = j;
   GDIAL_LOGINFO("there are %d non-empty elems", element_num);
-  if(element_num == 3 && g_strcmp0(instance,"dial_data") == 0)
+  if(element_num == 2 && g_strcmp0(instance,"dial_data") == 0)
   {
-    GDialAppRegistry *app_registry = gdial_rest_server_find_app_registry(gdial_rest_server, app_name);
+    GDialAppRegistry *app_registry = gdial_rest_server_find_app_registry_by_uuid(gdial_rest_server, base);
+
     gdial_rest_server_http_return_if_fail(app_registry, msg, SOUP_STATUS_NOT_FOUND);
     if (msg->method == SOUP_METHOD_POST) {
-       gdial_rest_server_handle_POST_dial_data(gdial_rest_server, msg, query, app_name);
+       gdial_rest_server_handle_POST_dial_data(gdial_rest_server, msg, query, app_registry->name);
     }
     else if (msg->method == SOUP_METHOD_GET) {
-     gdial_rest_server_handle_GET_app(gdial_rest_server, msg, query, app_name, GDIAL_APP_INSTANCE_NULL);
+     gdial_rest_server_handle_GET_app(gdial_rest_server, msg, query, app_registry->name, GDIAL_APP_INSTANCE_NULL);
     }
     else {
       gdial_rest_server_http_return_if_fail(msg->method == SOUP_METHOD_POST, msg, SOUP_STATUS_NOT_IMPLEMENTED);
@@ -1150,7 +1165,7 @@ gboolean gdial_rest_server_register_app(GDialRestServer *self, const gchar *app_
 
   if( 0 != strcmp(app_name,"system"))
   {
-    GDIAL_LOGINFO("gdial_local_rest_http_server_callback add handler for app_name:[%s]",app_name);
+    GDIAL_LOGINFO("gdial_local_rest_http_server_callback handler added for App[%s]uri[%s]instance[%x]",app_name,app_registry->app_uri,priv->local_soup_instance);
     soup_server_add_handler(priv->local_soup_instance, app_registry->app_uri, gdial_local_rest_http_server_callback, self, NULL);
   }
   GDIAL_LOGTRACE("Exiting ...");
@@ -1180,6 +1195,11 @@ gboolean gdial_rest_server_register_app_registry(GDialRestServer *self, GDialApp
 
   g_return_val_if_fail(priv->registered_apps != NULL, FALSE);
   g_return_val_if_fail(gdial_rest_server_is_app_registered(self, app_registry->name), FALSE);
+  if( 0 != strcmp(app_registry->name,"system"))
+  {
+    GDIAL_LOGINFO("gdial_local_rest_http_server_callback handler added for App[%s]uri[%s]instance[%x]",app_registry->name,app_registry->app_uri,priv->local_soup_instance);
+    soup_server_add_handler(priv->local_soup_instance, app_registry->app_uri, gdial_local_rest_http_server_callback, self, NULL);
+  }
   return TRUE;
 }
 

--- a/server/gdial-rest.h
+++ b/server/gdial-rest.h
@@ -50,7 +50,7 @@ gboolean gdial_rest_server_unregister_all_apps(GDialRestServer *self);
 typedef struct _GDialAppRegistry GDialAppRegistry;
 
 GDIAL_STATIC gboolean gdial_rest_server_is_allowed_origin(GDialRestServer *self, const gchar *header_origin, const gchar *app_name);
-GDIAL_STATIC gchar *gdial_rest_server_new_additional_data_url(guint listening_port, const gchar *app_name, gboolean encode);
+GDIAL_STATIC gchar *gdial_rest_server_new_additional_data_url(guint listening_port, const gchar *app_name, gboolean encode, const gchar* app_uri);
 GDIAL_STATIC GDialAppRegistry *gdial_rest_server_find_app_registry(GDialRestServer *self, const gchar *app_name);
 
 G_END_DECLS

--- a/server/gdial-rest.h
+++ b/server/gdial-rest.h
@@ -52,6 +52,7 @@ typedef struct _GDialAppRegistry GDialAppRegistry;
 GDIAL_STATIC gboolean gdial_rest_server_is_allowed_origin(GDialRestServer *self, const gchar *header_origin, const gchar *app_name);
 GDIAL_STATIC gchar *gdial_rest_server_new_additional_data_url(guint listening_port, const gchar *app_name, gboolean encode, const gchar* app_uri);
 GDIAL_STATIC GDialAppRegistry *gdial_rest_server_find_app_registry(GDialRestServer *self, const gchar *app_name);
+GDIAL_STATIC GDialAppRegistry *gdial_rest_server_find_app_registry_by_uuid(GDialRestServer *self, const gchar *app_uuid);
 
 G_END_DECLS
 

--- a/server/gdial-ssdp.c
+++ b/server/gdial-ssdp.c
@@ -75,6 +75,8 @@ static const char ssdp_device_xml_template[] = ""
 static gchar *dd_xml_response_str_ = NULL;
 static gchar *app_friendly_name = NULL;
 static gchar *app_random_uuid = NULL;
+static gchar *app_manufacturer_name = NULL;
+static gchar *app_model_name = NULL;
 static pthread_mutex_t ssdpServerEventSync = PTHREAD_MUTEX_INITIALIZER;
 
 static void ssdp_http_server_callback(SoupServer *server, SoupMessage *msg, const char *path, GHashTable *query, SoupClientContext  *client, gpointer user_data) {
@@ -95,8 +97,8 @@ static void ssdp_http_server_callback(SoupServer *server, SoupMessage *msg, cons
   static size_t dd_xml_response_str_len = 0;
 
   if (!dd_xml_response_str_) {
-    const gchar *manufacturer= gdial_plat_dev_get_manufacturer();
-    const gchar *model = gdial_plat_dev_get_model();
+    const gchar *manufacturer= app_manufacturer_name;
+    const gchar *model = app_model_name;
 
     if (manufacturer == NULL) {
         manufacturer = gdial_options_->manufacturer;
@@ -337,6 +339,46 @@ int gdial_ssdp_set_friendlyname(const gchar *friendlyname)
         app_friendly_name = g_strdup(friendlyname);
 
         GDIAL_LOGINFO("gdial_ssdp_set_friendlyname app_friendly_name :%s  ",app_friendly_name);
+        if (dd_xml_response_str_!= NULL){
+            g_free(dd_xml_response_str_);
+            dd_xml_response_str_ = NULL;
+        }
+    }
+    pthread_mutex_unlock(&ssdpServerEventSync);
+    return 0;
+}
+
+int gdial_ssdp_set_manufacturername(const gchar *manufacturer_name)
+{
+    pthread_mutex_lock(&ssdpServerEventSync);
+    if(manufacturer_name)
+    {
+        if (app_manufacturer_name != NULL) {
+            g_free(app_manufacturer_name);
+        }
+        app_manufacturer_name = g_strdup(manufacturer_name);
+
+        GDIAL_LOGINFO("app_manufacturer_name :%s  ",app_manufacturer_name);
+        if (dd_xml_response_str_!= NULL){
+            g_free(dd_xml_response_str_);
+            dd_xml_response_str_ = NULL;
+        }
+    }
+    pthread_mutex_unlock(&ssdpServerEventSync);
+    return 0;
+}
+
+int gdial_ssdp_set_modelname(const gchar *model_name)
+{
+    pthread_mutex_lock(&ssdpServerEventSync);
+    if(model_name)
+    {
+        if (app_model_name != NULL) {
+            g_free(app_model_name);
+        }
+        app_model_name = g_strdup(model_name);
+
+        GDIAL_LOGINFO("app_model_name :%s  ",app_model_name);
         if (dd_xml_response_str_!= NULL){
             g_free(dd_xml_response_str_);
             dd_xml_response_str_ = NULL;

--- a/server/gdial-ssdp.h
+++ b/server/gdial-ssdp.h
@@ -30,6 +30,8 @@ int gdial_ssdp_new(SoupServer *server, GDialOptions *options, const gchar *rando
 int gdial_ssdp_destroy();
 int gdial_ssdp_set_available(bool activationStatus, const gchar *friendlyName);
 int gdial_ssdp_set_friendlyname(const gchar *friendlyName);
+int gdial_ssdp_set_manufacturername(const gchar *manufacturer_name);
+int gdial_ssdp_set_modelname(const gchar *model_name);
 G_END_DECLS
 
 #endif

--- a/server/gdialservice.cpp
+++ b/server/gdialservice.cpp
@@ -171,6 +171,16 @@ static void server_friendlyname_handler(const gchar * friendlyname)
     gdial_ssdp_set_friendlyname(friendlyname);
 }
 
+static void server_manufacturername_handler(const gchar * manufacturername)
+{
+    gdial_ssdp_set_manufacturername(manufacturername);
+}
+
+static void server_modelname_handler(const gchar * modelname)
+{
+    gdial_ssdp_set_modelname(modelname);
+}
+
 static void server_powerstate_handler(const gchar * powerState)
 {
     gdialServiceImpl::getInstance()->updatePowerState(std::string(powerState));
@@ -268,6 +278,10 @@ int gdialServiceImpl::start_GDialServer(int argc, char *argv[])
 
     gdail_plat_register_activation_cb(server_activation_handler);
     gdail_plat_register_friendlyname_cb(server_friendlyname_handler);
+
+    gdail_plat_register_manufacturername_cb(server_manufacturername_handler);
+    gdail_plat_register_modelname_cb(server_modelname_handler);
+
     gdail_plat_register_registerapps_cb (server_register_application);
     gdail_plat_dev_register_powerstate_cb(server_powerstate_handler);
 
@@ -678,6 +692,18 @@ void *gdialServiceImpl::requestHandlerThread(void *ctx)
                     gdial_plat_application_update_network_standby_mode((gboolean)reqHdlrPayload.user_param1);
                 }
                 break;
+                case UPDATE_MANUFACTURER_NAME:
+                {
+                    GDIAL_LOGINFO("UPDATE_MANUFACTURER_NAME : data:%s",reqHdlrPayload.manufacturer.c_str());
+                    gdial_plat_application_update_manufacturer_name(reqHdlrPayload.manufacturer.c_str());
+                }
+                break;
+                case UPDATE_MODEL_NAME:
+                {
+                    GDIAL_LOGINFO("UPDATE_MODEL_NAME : data:%s",reqHdlrPayload.model.c_str());
+                    gdial_plat_application_update_model_name(reqHdlrPayload.model.c_str());
+                }
+                break;
                 default:
                 {
 
@@ -1041,6 +1067,39 @@ void gdialService::setNetworkStandbyMode(bool nwStandbymode)
         gdialImplInstance->sendRequest(payload);
     }
     GDIAL_LOGTRACE("Exiting ...");
+}
+
+
+GDIAL_SERVICE_ERROR_CODES gdialService::setManufacturerName(string manufacturer)
+{
+    gdialServiceImpl* gdialImplInstance = gdialServiceImpl::getInstance();
+    GDIAL_LOGTRACE("Entering ...");
+    GDIAL_LOGINFO("Manufacturer[%s]",manufacturer.c_str());
+    if ((nullptr != m_gdialService ) && (nullptr != gdialImplInstance))
+    {
+        RequestHandlerPayload payload;
+        payload.event = UPDATE_MANUFACTURER_NAME;
+        payload.manufacturer = manufacturer;
+        gdialImplInstance->sendRequest(payload);
+    }
+    GDIAL_LOGTRACE("Exiting ...");
+    return GDIAL_SERVICE_ERROR_NONE;
+}
+
+GDIAL_SERVICE_ERROR_CODES gdialService::setModelName(string model)
+{
+    gdialServiceImpl* gdialImplInstance = gdialServiceImpl::getInstance();
+    GDIAL_LOGTRACE("Entering ...");
+    GDIAL_LOGINFO("Model[%s]",model.c_str());
+    if ((nullptr != m_gdialService ) && (nullptr != gdialImplInstance))
+    {
+        RequestHandlerPayload payload;
+        payload.event = UPDATE_MODEL_NAME;
+        payload.model = model;
+        gdialImplInstance->sendRequest(payload);
+    }
+    GDIAL_LOGTRACE("Exiting ...");
+    return GDIAL_SERVICE_ERROR_NONE;
 }
 
 void gdialServiceImpl::sendRequest( const RequestHandlerPayload& payload )

--- a/server/include/gdial-plat-app.h
+++ b/server/include/gdial-plat-app.h
@@ -32,9 +32,13 @@ typedef void * gdial_async_handler_t;
 typedef void (*gdial_plat_activation_cb)(gboolean, const gchar *);
 typedef void (*gdial_plat_friendlyname_cb)(const gchar *);
 typedef void (*gdial_plat_registerapps_cb)(gpointer);
+typedef void (*gdial_plat_manufacturername_cb)(const gchar *);
+typedef void (*gdial_plat_modelname_cb)(const gchar *);
 void gdail_plat_register_activation_cb(gdial_plat_activation_cb cb);
 void gdail_plat_register_friendlyname_cb(gdial_plat_friendlyname_cb cb);
 void gdail_plat_register_registerapps_cb(gdial_plat_registerapps_cb cb);
+void gdail_plat_register_manufacturername_cb(gdial_plat_manufacturername_cb cb);
+void gdail_plat_register_modelname_cb(gdial_plat_modelname_cb cb);
 
 GDialAppError gdial_plat_application_start(const gchar *app_name, const gchar *payload, const gchar *query, const gchar *additional_data_url, gint *instance_id);
 GDialAppError gdial_plat_application_hide(const gchar *app_name, gint instance_id);
@@ -48,6 +52,8 @@ GDialAppError gdial_plat_application_friendlyname_changed(const char *friendlyna
 const char* gdial_plat_application_get_protocol_version();
 GDialAppError gdial_plat_application_register_applications(void*);
 void gdial_plat_application_update_network_standby_mode(gboolean nwstandbyMode);
+GDialAppError gdial_plat_application_update_manufacturer_name(const char *manufacturer);
+GDialAppError gdial_plat_application_update_model_name(const char *model);
 GDialAppError gdial_plat_application_service_notification(gboolean isNotifyRequired, void* notifier);
 
 void * gdial_plat_application_start_async(const gchar *app_name, const gchar *payload, const gchar *query, const gchar *additional_data_url, void *user_data);

--- a/server/include/gdial-plat-dev.h
+++ b/server/include/gdial-plat-dev.h
@@ -26,8 +26,6 @@
 extern "C" {
 #endif
 
-const char * gdial_plat_dev_get_manufacturer();
-const char * gdial_plat_dev_get_model();
 bool gdial_plat_dev_set_power_state_on();
 bool gdial_plat_dev_set_power_state_off();
 bool gdial_plat_dev_toggle_power_state();

--- a/server/include/gdial_app_registry.h
+++ b/server/include/gdial_app_registry.h
@@ -32,7 +32,10 @@
 
 G_BEGIN_DECLS
 
+#define APP_MAX_UUID_SIZE 64
+
 typedef struct _GDialAppRegistry {
+  gchar app_uri[APP_MAX_UUID_SIZE+1]; // for storing uri
   gchar *name;
   gboolean use_additional_data;
   gboolean is_singleton;

--- a/server/include/gdialservice.h
+++ b/server/include/gdialservice.h
@@ -41,6 +41,8 @@ public:
     string getProtocolVersion(void);
     GDIAL_SERVICE_ERROR_CODES RegisterApplications(RegisterAppEntryList* appConfigList);
     void setNetworkStandbyMode(bool nwStandbymode);
+    GDIAL_SERVICE_ERROR_CODES setManufacturerName(string manufacturer);
+    GDIAL_SERVICE_ERROR_CODES setModelName(string model);
 
 private:
     GDialNotifier* m_observer{nullptr};

--- a/server/include/gdialserviceimpl.h
+++ b/server/include/gdialserviceimpl.h
@@ -37,6 +37,8 @@ typedef enum _AppRequestEvents
     FRIENDLYNAME_CHANGED,
     REGISTER_APPLICATIONS,
     UPDATE_NW_STANDBY,
+    UPDATE_MANUFACTURER_NAME,
+    UPDATE_MODEL_NAME,
     INVALID_REQUEST
 }
 AppRequestEvents;
@@ -59,6 +61,8 @@ typedef struct _RequestHandlerPayload
     std::string appIdOractivation;
     std::string state;
     std::string error;
+    std::string manufacturer;
+    std::string model;
     void* data_param;
     bool user_param1;
     AppRequestEvents event;

--- a/server/plat/CMakeLists.txt
+++ b/server/plat/CMakeLists.txt
@@ -69,4 +69,4 @@ if(PLATFORM)
 endif()
 
 add_library(gdial-plat SHARED ${GDIAL_PLAT_LIB_SOURCE_FILES})
-target_link_Libraries(gdial-plat PRIVATE ${GLIB_LIBRARIES} ${GOBJECT_LIBRARIES} -lpthread -lWPEFrameworkCore -lWPEFrameworkDefinitions -lWPEFrameworkCOM -lWPEFrameworkPlugins -lWPEFrameworkSecurityUtil -lIARMBus)
+target_link_Libraries(gdial-plat PRIVATE ${GLIB_LIBRARIES} ${GOBJECT_LIBRARIES} -lpthread -lWPEFrameworkCore -lWPEFrameworkDefinitions -lWPEFrameworkCOM -lWPEFrameworkPlugins -lWPEFrameworkSecurityUtil -lIARMBus -luuid)

--- a/server/plat/gdial-os-app.h
+++ b/server/plat/gdial-os-app.h
@@ -39,6 +39,8 @@ int gdial_os_application_friendlyname_changed(const char *friendlyname);
 const char* gdial_os_application_get_protocol_version();
 int gdial_os_application_register_applications(void*);
 void gdial_os_application_update_network_standby_mode(gboolean nwstandbyMode);
+int gdial_os_application_update_manufacturer_name(const char *manufacturer);
+int gdial_os_application_update_model_name(const char *model);
 int gdial_os_application_service_notification(gboolean isNotifyRequired, void* notifier);
 
 #ifdef __cplusplus

--- a/server/plat/gdial-plat-app.c
+++ b/server/plat/gdial-plat-app.c
@@ -35,6 +35,8 @@ static gpointer gdial_app_state_cb_user_data_ = NULL;
 static gdial_plat_activation_cb g_activation_cb = NULL;
 static gdial_plat_friendlyname_cb g_friendlyname_cb = NULL;
 static gdial_plat_registerapps_cb g_registerapps_cb = NULL;
+static gdial_plat_manufacturername_cb g_manufacturername_cb = NULL;
+static gdial_plat_modelname_cb g_modelname_cb = NULL;
 
 #define GDIAL_PLAT_APP_ASYNC_CONTEXT_TYPE_COMMON 0
 #define GDIAL_PLAT_APP_ASYNC_CONTEXT_TYPE_START  1
@@ -149,6 +151,18 @@ void gdail_plat_register_registerapps_cb(gdial_plat_registerapps_cb cb)
 {
   g_registerapps_cb = cb;
   gdial_register_registerapps_cb(cb);
+}
+
+void gdail_plat_register_manufacturername_cb(gdial_plat_manufacturername_cb cb)
+{
+  g_manufacturername_cb = cb;
+  gdial_register_manufacturername_cb(cb);
+}
+
+void gdail_plat_register_modelname_cb(gdial_plat_modelname_cb cb)
+{
+  g_modelname_cb = cb;
+  gdial_register_modelname_cb(cb);
 }
 
 gint gdial_plat_init(GMainContext *main_context) {
@@ -334,6 +348,20 @@ GDialAppError gdial_plat_application_register_applications(void* appList)
 void gdial_plat_application_update_network_standby_mode(gboolean nwstandby)
 {
   gdial_os_application_update_network_standby_mode(nwstandby);
+}
+
+GDialAppError gdial_plat_application_update_manufacturer_name(const char *manufacturer)
+{
+  g_return_val_if_fail(manufacturer != NULL, GDIAL_APP_ERROR_BAD_REQUEST);
+
+  return gdial_os_application_update_manufacturer_name(manufacturer);
+}
+
+GDialAppError gdial_plat_application_update_model_name(const char *model)
+{
+  g_return_val_if_fail(model != NULL, GDIAL_APP_ERROR_BAD_REQUEST);
+
+  return gdial_os_application_update_model_name(model);
 }
 
 GDialAppError gdial_plat_application_service_notification(gboolean isNotifyRequired, void* notifier)

--- a/server/plat/gdial-plat-dev.c
+++ b/server/plat/gdial-plat-dev.c
@@ -25,14 +25,6 @@
 static gdial_plat_dev_nwstandbymode_cb g_nwstandbymode_cb = NULL;
 static gdial_plat_dev_powerstate_cb g_powerstate_cb = NULL;
 
-const char * gdial_plat_dev_get_manufacturer() {
-  return g_getenv("GDIAL_DEV_MANUFACTURER");
-}
-
-const char * gdial_plat_dev_get_model() {
-  return g_getenv("GDIAL_DEV_MODEL");
-}
-
 void gdial_plat_dev_nwstandby_mode_change(gboolean NetworkStandbyMode)
 {
     if(g_nwstandbymode_cb) g_nwstandbymode_cb(NetworkStandbyMode);

--- a/server/plat/gdial.cpp
+++ b/server/plat/gdial.cpp
@@ -49,6 +49,8 @@ GDialAppStatusCache* AppCache = nullptr;
 static gdial_activation_cb g_activation_cb = NULL;
 static gdial_friendlyname_cb g_friendlyname_cb = NULL;
 static gdial_registerapps_cb g_registerapps_cb = NULL;
+static gdial_manufacturername_cb g_manufacturername_cb = NULL;
+static gdial_modelname_cb g_modelname_cb = NULL;
 
 #define DIAL_MAX_NUM_OF_APPS (64)
 #define DIAL_MAX_NUM_OF_APP_NAMES (64)
@@ -68,7 +70,7 @@ public:
         AppInfo* AppObj = new AppInfo(applicationName,applicationId,state,error);
         if ((nullptr != AppObj) && (nullptr != AppCache))
         {
-            GDIAL_LOGINFO("AppName : %s AppID : %s State : %s Error : %s",
+            GDIAL_LOGINFO("AppName[%s] AppID[%s] State[%s] Error[%s]",
                             AppObj->appName.c_str(),
                             AppObj->appId.c_str(),
                             AppObj->appState.c_str(),
@@ -88,7 +90,7 @@ public:
         GDialErrorCode error = GDIAL_CAST_ERROR_INTERNAL;
         if( g_friendlyname_cb && friendlyname )
         {
-            GDIAL_LOGINFO("GDialCastObject::friendlyNameChanged :%s ",friendlyname);
+            GDIAL_LOGINFO("GDialCastObject::friendlyNameChanged:[%s]",friendlyname);
             g_friendlyname_cb(friendlyname);
             error = GDIAL_CAST_ERROR_NONE;
         }
@@ -111,7 +113,7 @@ public:
             {
                 break;
             }
-            GDIAL_LOGINFO("Application: %d ", i);
+            GDIAL_LOGINFO("Application:[%d]", i);
             gAppPrefxes = g_list_prepend (gAppPrefxes, g_strdup(appEntry->prefixes.c_str()));
             GDIAL_LOGINFO("%s, ", appEntry->prefixes.c_str());
             GDIAL_LOGINFO("");
@@ -123,7 +125,7 @@ public:
             GHashTable *gProperties = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
             std::string appAllowStop = appEntry->allowStop ? "true" : "false";
             g_hash_table_insert(gProperties,g_strdup("allowStop"),g_strdup(appAllowStop.c_str()));
-            GDIAL_LOGINFO("allowStop: %s", appAllowStop.c_str());
+            GDIAL_LOGINFO("allowStop:[%s]", appAllowStop.c_str());
             GDIAL_LOGINFO("");
 
             GDialAppRegistry*  app_registry = gdial_app_registry_new( g_strdup(appEntry->Names.c_str()),
@@ -165,7 +167,7 @@ public:
     {
         GDIAL_LOGTRACE("Entering ...");
         GDialErrorCode error = GDIAL_CAST_ERROR_INTERNAL;
-        GDIAL_LOGINFO("status: %s friendlyname: %s ",status.c_str(),friendlyName.c_str());
+        GDIAL_LOGINFO("status[%s] friendlyname[%s]",status.c_str(),friendlyName.c_str());
         if( g_activation_cb )
         {
             if(!strcmp(status.c_str(), "true"))
@@ -176,7 +178,7 @@ public:
             {
                 g_activation_cb(0,friendlyName.c_str());
             }
-            GDIAL_LOGINFO("status: %s  g_activation_cb :%p",status.c_str(), g_activation_cb);
+            GDIAL_LOGINFO("status[%s]  g_activation_cb[%p]",status.c_str(), g_activation_cb);
             error = GDIAL_CAST_ERROR_NONE;
         }
         GDIAL_LOGTRACE("Exiting ...");
@@ -189,14 +191,48 @@ public:
         gdial_plat_dev_nwstandby_mode_change(nwstandbyMode);
         GDIAL_LOGTRACE("Exiting ...");
     }
+
+    GDialErrorCode updateManufacturerName(const char* manufacturerName)
+    {
+        GDIAL_LOGTRACE("Entering ...");
+        GDialErrorCode error = GDIAL_CAST_ERROR_INTERNAL;
+        if( g_manufacturername_cb && manufacturerName )
+        {
+            GDIAL_LOGINFO("Manufacturer[%s]",manufacturerName);
+            g_manufacturername_cb(manufacturerName);
+            error = GDIAL_CAST_ERROR_NONE;
+        }
+        GDIAL_LOGTRACE("Exiting ...");
+        return error;
+    }
+
+    GDialErrorCode updateModelName(const char* modelName)
+    {
+        GDIAL_LOGTRACE("Entering ...");
+        GDialErrorCode error = GDIAL_CAST_ERROR_INTERNAL;
+        if( g_modelname_cb && modelName )
+        {
+            GDIAL_LOGINFO("ModelName[%s]",modelName);
+            g_modelname_cb(modelName);
+            error = GDIAL_CAST_ERROR_NONE;
+        }
+        GDIAL_LOGTRACE("Exiting ...");
+        return error;
+    }
     
     GDialErrorCode launchApplication(const char* appName, const char* args)
     {
         GDIAL_LOGTRACE("Entering ...");
         std::string applicationName = "",
                     parameter = "";
-        if (nullptr!=appName) applicationName = appName;
-        if (nullptr!=args) parameter = args;
+
+        if (nullptr!=appName){
+            applicationName = appName;
+        }
+
+        if (nullptr!=args){
+            parameter = args;
+        }
 
         GDIAL_LOGINFO("App[%s] param[%s] observer[%p]",applicationName.c_str(),parameter.c_str(),m_observer);
         if (nullptr!=m_observer)
@@ -215,10 +251,18 @@ public:
                         additionalDataUrl = "";
         GDIAL_LOGTRACE("Entering ...");
 
-        if (nullptr!=appName) applicationName = appName;
-        if (nullptr!=argPayload) payLoad = argPayload;
-        if (nullptr!=argQueryString) queryString = argQueryString;
-        if (nullptr!=argAdditionalDataUrl) additionalDataUrl = argAdditionalDataUrl;
+        if (nullptr!=appName){
+            applicationName = appName;
+        }
+        if (nullptr!=argPayload){
+            payLoad = argPayload;
+        }
+        if (nullptr!=argQueryString){
+            queryString = argQueryString;
+        }
+        if (nullptr!=argAdditionalDataUrl){
+            additionalDataUrl = argAdditionalDataUrl;
+        }
 
         GDIAL_LOGINFO("App[%s] payload[%s] query_string[%s] additional_data_url[%s]observer[%p]",
                 applicationName.c_str(), 
@@ -242,8 +286,12 @@ public:
         GDIAL_LOGTRACE("Entering ...");
         std::string applicationName = "",
                     applicationId = "";
-        if (nullptr!=appName) applicationName = appName;
-        if (nullptr!=appID) applicationId = appID;
+        if (nullptr!=appName){
+            applicationName = appName;
+        }
+        if (nullptr!=appID){
+            applicationId = appID;
+        }
 
         GDIAL_LOGINFO("App[%s]ID[%s]observer[%p]",applicationName.c_str(),applicationId.c_str(),m_observer);
         if (nullptr!=m_observer)
@@ -260,8 +308,12 @@ public:
         std::string applicationName = "",
                     applicationId = "";
 
-        if (nullptr!=appName) applicationName = appName;
-        if (nullptr!=appID) applicationId = appID;
+        if (nullptr!=appName){
+            applicationName = appName;
+        }
+        if (nullptr!=appID){
+            applicationId = appID;
+        }
 
         GDIAL_LOGINFO("App[%s]ID[%s]observer[%p]",applicationName.c_str(),applicationId.c_str(),m_observer);
         if (nullptr!=m_observer)
@@ -278,8 +330,12 @@ public:
         std::string applicationName = "",
                     applicationId = "";
 
-        if (nullptr!=appName) applicationName = appName;
-        if (nullptr!=appID) applicationId = appID;
+        if (nullptr!=appName){
+            applicationName = appName;
+        }
+        if (nullptr!=appID){
+            applicationId = appID;
+        }
 
         GDIAL_LOGINFO("App[%s]ID[%s]observer[%p]",applicationName.c_str(),applicationId.c_str(),m_observer);
         if (nullptr!=m_observer)
@@ -296,8 +352,12 @@ public:
         std::string applicationName = "",
                     applicationId = "";
 
-        if (nullptr!=appName) applicationName = appName;
-        if (nullptr!=appID) applicationId = appID;
+        if (nullptr!=appName){
+            applicationName = appName;
+        }
+        if (nullptr!=appID){
+            applicationId = appID;
+        }
 
         GDIAL_LOGINFO("App[%s]ID[%s]observer[%p]",applicationName.c_str(),applicationId.c_str(),m_observer);
         if (nullptr!=m_observer)
@@ -331,6 +391,16 @@ void gdial_register_friendlyname_cb(gdial_friendlyname_cb cb)
 void gdial_register_registerapps_cb(gdial_registerapps_cb cb)
 {
    g_registerapps_cb = cb;
+}
+
+void gdial_register_manufacturername_cb(gdial_manufacturername_cb cb)
+{
+    g_manufacturername_cb = cb;
+}
+
+void gdial_register_modelname_cb(gdial_modelname_cb cb)
+{
+    g_modelname_cb = cb;
 }
 
 bool gdial_init(GMainContext *context)
@@ -435,7 +505,7 @@ map<string,string> parse_query(const char* query_string) {
 
 int gdial_os_application_start(const char *app_name, const char *payload, const char *query_string, const char *additional_data_url, int *instance_id) {
     GDIAL_LOGTRACE("Entering ...");
-    GDIAL_LOGINFO("App launch req: appName: %s  query: [%s], payload: [%s], additionalDataUrl [%s] instance[%p]",
+    GDIAL_LOGINFO("App launch req: appName[%s]  query[%s], payload[%s], additionalDataUrl [%s] instance[%p]",
         app_name, query_string, payload, additional_data_url,instance_id);
 
     if (strcmp(app_name,"system") == 0) {
@@ -508,20 +578,20 @@ std::string GetCurrentState() {
          } else {
            string sToken = (char*)buffer;
            string query = "token=" + sToken;
-           GDIAL_LOGINFO("Security token = %s ",query.c_str());
+           GDIAL_LOGINFO("Security token[%s] ",query.c_str());
            controllerRemoteObject = new JSONRPC::LinkType<Core::JSON::IElement>(std::string(), false, query);
          }
      }
      std::string nfxstatus = "status@" + nfx_callsign;
      if(controllerRemoteObject->Get(1000, _T(nfxstatus), pluginResponse) == Core::ERROR_NONE)
      {
-         GDIAL_LOGINFO("Obtained netflix status = %s",nfxstatus.c_str());
+         GDIAL_LOGINFO("Obtained netflix status[%s]",nfxstatus.c_str());
          Core::JSON::ArrayType<PluginHost::MetaData::Service>::Iterator index(pluginResponse.Elements());
          while (index.Next() == true) {
                 netflixState = index.Current().JSONState.Data();
          } //end of while loop
      } //end of if case for querrying
-     GDIAL_LOGINFO("Netflix State = %s",netflixState.c_str());
+     GDIAL_LOGINFO("Netflix State[%s]",netflixState.c_str());
      return netflixState;
 }
 void stop_netflix()
@@ -541,7 +611,7 @@ void stop_netflix()
 int gdial_os_application_stop(const char *app_name, int instance_id) {
     bool enable_stop = false;
     GDIAL_LOGTRACE("Entering ...");
-    GDIAL_LOGINFO("AppName = %s appID = %s",app_name,std::to_string(instance_id).c_str());
+    GDIAL_LOGINFO("AppName[%s] appID[%s]",app_name,std::to_string(instance_id).c_str());
     if((strcmp(app_name,"system") == 0)){
         GDIAL_LOGINFO("delete not supported for system app return GDIAL_APP_ERROR_BAD_REQUEST");
         return GDIAL_APP_ERROR_BAD_REQUEST;
@@ -591,7 +661,7 @@ int gdial_os_application_hide(const char *app_name, int instance_id)
         return GDIAL_APP_ERROR_NONE;
     }
     #if 0
-    GDIAL_LOGINFO("gdial_os_application_hide-->stop: appName = %s appID = %s",app_name,std::to_string(instance_id).c_str());
+    GDIAL_LOGINFO("gdial_os_application_hide-->stop: appName[%s] appID[%s]",app_name,std::to_string(instance_id).c_str());
     std::string State = AppCache->SearchAppStatusInCache(app_name);
     if (0 && State != "running") {
         return GDIAL_APP_ERROR_BAD_REQUEST;
@@ -607,7 +677,7 @@ int gdial_os_application_hide(const char *app_name, int instance_id)
     }
     return GDIAL_APP_ERROR_NONE;
     #else
-    GDIAL_LOGINFO("gdial_os_application_hide: appName = %s appID = %s",app_name,std::to_string(instance_id).c_str());
+    GDIAL_LOGINFO("gdial_os_application_hide: appName[%s] appID[%s]",app_name,std::to_string(instance_id).c_str());
     std::string State = AppCache->SearchAppStatusInCache(app_name);
     if (State != "running")
     {
@@ -635,7 +705,7 @@ int gdial_os_application_hide(const char *app_name, int instance_id)
 
 int gdial_os_application_resume(const char *app_name, int instance_id) {
     GDIAL_LOGTRACE("Entering ...");
-    GDIAL_LOGINFO("appName = %s appID = %s",app_name,std::to_string(instance_id).c_str());
+    GDIAL_LOGINFO("appName[%s] appID[%s]",app_name,std::to_string(instance_id).c_str());
 
     if((strcmp(app_name,"system") == 0)){
         GDIAL_LOGINFO("system app can not be resume");
@@ -668,7 +738,7 @@ int gdial_os_application_resume(const char *app_name, int instance_id) {
 
 int gdial_os_application_state(const char *app_name, int instance_id, GDialAppState *state) {
     GDIAL_LOGTRACE("Entering ...");
-    GDIAL_LOGINFO("App = %s Id = %d",app_name,instance_id);
+    GDIAL_LOGINFO("App[%s] Id[%d]",app_name,instance_id);
     if((strcmp(app_name,"system") == 0)){
         *state = GDIAL_APP_STATE_HIDE;
         GDIAL_LOGINFO("getApplicationState: AppState = suspended ");
@@ -676,7 +746,7 @@ int gdial_os_application_state(const char *app_name, int instance_id, GDialAppSt
         return GDIAL_APP_ERROR_NONE;
     }
     std::string State = AppCache->SearchAppStatusInCache(app_name);
-    GDIAL_LOGINFO("getApplicationState: AppState = %s ",State.c_str());
+    GDIAL_LOGINFO("getApplicationState: AppState[%s] ",State.c_str());
     /*
      *  return cache, but also trigger a refresh
      */
@@ -710,7 +780,7 @@ int gdial_os_application_state(const char *app_name, int instance_id, GDialAppSt
     if ( enable_stop != NULL ) {
        if (strcmp(app_name,"Netflix") == 0 && strcmp(enable_stop,"true") == 0) {
          std::string app_state = GetCurrentState();
-         GDIAL_LOGINFO("Presence of Netflix thunder plugin state = %s to confirm state", app_state.c_str());
+         GDIAL_LOGINFO("Presence of Netflix thunder plugin state[%s] to confirm state", app_state.c_str());
          if (app_state == "deactivated") {
            *state = GDIAL_APP_STATE_STOPPED;
            GDIAL_LOGINFO("app [%s] state converted to [%d]", app_name, *state);
@@ -732,7 +802,7 @@ int gdial_os_application_state(const char *app_name, int instance_id, GDialAppSt
 int gdial_os_application_state_changed(const char *applicationName, const char *applicationId, const char *state, const char *error)
 {
     GDIAL_LOGTRACE("Entering ...");
-    GDIAL_LOGINFO("appName: %s  appId: [%s], state: [%s], error [%s]",applicationName, applicationId, state, error);
+    GDIAL_LOGINFO("appName[%s]  appId[%s], state[%s], error [%s]",applicationName, applicationId, state, error);
 
     if (nullptr == GDialObjHandle)
     {
@@ -755,7 +825,7 @@ int gdial_os_application_state_changed(const char *applicationName, const char *
 int gdial_os_application_activation_changed(const char *activation, const char *friendlyname)
 {
     GDIAL_LOGTRACE("Entering ...");
-    GDIAL_LOGINFO("activation: %s  friendlyname: [%s]",activation, friendlyname);
+    GDIAL_LOGINFO("activation[%s]  friendlyname[%s]",activation, friendlyname);
 
     if (nullptr == GDialObjHandle)
     {
@@ -778,7 +848,7 @@ int gdial_os_application_activation_changed(const char *activation, const char *
 int gdial_os_application_friendlyname_changed(const char *friendlyname)
 {
     GDIAL_LOGTRACE("Entering ...");
-    GDIAL_LOGINFO("friendlyname: [%s]",friendlyname);
+    GDIAL_LOGINFO("friendlyname[%s]",friendlyname);
 
     if (nullptr == GDialObjHandle)
     {
@@ -847,6 +917,47 @@ void gdial_os_application_update_network_standby_mode(gboolean nwstandbymode)
         GDialObjHandle->updateNetworkStandbyMode(nwstandbymode);
     }
     GDIAL_LOGTRACE("Exiting ...");
+}
+
+int gdial_os_application_update_manufacturer_name(const char *manufacturer)
+{
+    GDialErrorCode returnValue = GDIAL_CAST_ERROR_INTERNAL;
+    GDIAL_LOGTRACE("Entering ...");
+    if ((nullptr == GDialObjHandle)||(nullptr == manufacturer))
+    {
+        GDIAL_LOGERROR("NULL GDialObjHandle[%p] manufacturer[%p]",GDialObjHandle,manufacturer);
+    }
+    else
+    {
+        GDIAL_LOGINFO("Manufacturer[%s]", manufacturer);
+        returnValue = GDialObjHandle->updateManufacturerName(manufacturer);
+        if (returnValue != GDIAL_CAST_ERROR_NONE) {
+            GDIAL_LOGERROR("Failed to updateManufacturerName. Error=%x",returnValue);
+        }
+    }
+
+    GDIAL_LOGTRACE("Exiting ...");
+    return returnValue;
+}
+
+int gdial_os_application_update_model_name(const char *model)
+{
+    GDialErrorCode returnValue = GDIAL_CAST_ERROR_INTERNAL;
+    GDIAL_LOGTRACE("Entering ...");
+    if ((nullptr == GDialObjHandle)||(nullptr == model))
+    {
+        GDIAL_LOGERROR("NULL GDialObjHandle[%p] manufacturer[%p]",GDialObjHandle,model);
+    }
+    else
+    {
+        GDIAL_LOGINFO("Model[%s]", model);
+        returnValue = GDialObjHandle->updateModelName(model);
+        if (returnValue != GDIAL_CAST_ERROR_NONE) {
+            GDIAL_LOGERROR("Failed to updateModelName. Error=%x",returnValue);
+        }
+    }
+    GDIAL_LOGTRACE("Exiting ...");
+    return returnValue;
 }
 
 int gdial_os_application_service_notification(gboolean isNotifyRequired, void* notifier)

--- a/server/plat/gdial.hpp
+++ b/server/plat/gdial.hpp
@@ -45,9 +45,14 @@ void gdial_term();
 typedef void (*gdial_activation_cb)(bool, const gchar *);
 typedef void (*gdial_friendlyname_cb)(const gchar *);
 typedef void (*gdial_registerapps_cb)(gpointer);
+typedef void (*gdial_manufacturername_cb)(const gchar *);
+typedef void (*gdial_modelname_cb)(const gchar *);
+
 void gdial_register_activation_cb(gdial_activation_cb cb);
 void gdial_register_friendlyname_cb(gdial_friendlyname_cb cb);
 void gdial_register_registerapps_cb(gdial_registerapps_cb cb);
+void gdial_register_manufacturername_cb(gdial_manufacturername_cb cb);
+void gdial_register_modelname_cb(gdial_manufacturername_cb cb);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
RDK-55044: Implement DIAL requirement to use on EU product

Reason for change: Implemented setManufacturerName and setModelName APIs for DIAL Server name configuration
maintained the additional data url to specific app
Test Procedure: DIAL should work
Risks: None
Priority: P1

Signed-off-by: yuvaramachandran_gurusamy [yuvaramachandran_gurusamy@comcast.com]