### PR TITLE
RDKEMW-2278: Removal of WPEFrameworkSecurity Agent Utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,6 @@
 DIRS:= server
 
 all:
-	for dir in $(DIRS); do (cd $$dir && cmake $(PLATFORM_FLAGS) . && make || exit 1) || exit 1; done
+	for dir in $(DIRS); do (cd $$dir && cmake $(PLATFORM_FLAGS) $(DISABLE_FLAG) . && make || exit 1) || exit 1; done
 clean:
 	for dir in $(DIRS); do (cd $$dir && make clean || exit 1) || exit 1; done

--- a/server/plat/CMakeLists.txt
+++ b/server/plat/CMakeLists.txt
@@ -27,6 +27,10 @@ set (GDIAL_PLAT_DEPEND_LIBRARIES "${GLIB_LIBRARIES} ${GOBJECT_LIBRARIES}")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS} -std=c++11 -Wno-nonnull -DRT_PLATFORM_LINUX")
 
+if(DISABLE_SECURITY_TOKEN)
+  add_definitions(-DDISABLE_SECURITY_TOKEN)
+endif()
+
 #
 # Template that generates .pc file
 #
@@ -69,4 +73,10 @@ if(PLATFORM)
 endif()
 
 add_library(gdial-plat SHARED ${GDIAL_PLAT_LIB_SOURCE_FILES})
-target_link_Libraries(gdial-plat PRIVATE ${GLIB_LIBRARIES} ${GOBJECT_LIBRARIES} -lpthread -lWPEFrameworkCore -lWPEFrameworkDefinitions -lWPEFrameworkCOM -lWPEFrameworkPlugins -lWPEFrameworkSecurityUtil -lIARMBus -luuid)
+target_link_Libraries(gdial-plat PRIVATE ${GLIB_LIBRARIES} ${GOBJECT_LIBRARIES} -lpthread -lWPEFrameworkCore -lWPEFrameworkDefinitions -lWPEFrameworkCOM -lWPEFrameworkPlugins -lWPEFrameworkSecurityUtil -lIARMBus)
+
+if(DISABLE_SECURITY_TOKEN)
+  target_link_Libraries(gdial-plat PRIVATE ${GLIB_LIBRARIES} ${GOBJECT_LIBRARIES} -lpthread -lWPEFrameworkCore -lWPEFrameworkDefinitions -lWPEFrameworkCOM -lWPEFrameworkPlugins -lIARMBus)
+else()
+  target_link_libraries(gdial-plat PRIVATE ${GLIB_LIBRARIES} ${GOBJECT_LIBRARIES} -lpthread -lWPEFrameworkCore -lWPEFrameworkDefinitions -lWPEFrameworkCOM -lWPEFrameworkPlugins -lWPEFrameworkSecurityUtil -lIARMBus)
+endif()


### PR DESCRIPTION
Reason for change: Added DISABLE_SECURITY_TOKEN Flag to disable the WPEFrameworkSecurity Token generation changes
Test Procedure: please referred from the ticket
Risks: Medium
Signed-off-by: Thamim Razith ThamimRazith_AbbasAli@comcast.com