### PR TITLE
RDKEMW-2278: Removal of WPEFrameworkSecurity Agent Utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,6 @@
 DIRS:= server
 
 all:
-	for dir in $(DIRS); do (cd $$dir && cmake $(PLATFORM_FLAGS) . && make || exit 1) || exit 1; done
+	for dir in $(DIRS); do (cd $$dir && cmake $(DISABLE_SECURITY_TOKEN) $(PLATFORM_FLAGS) . && make || exit 1) || exit 1; done
 clean:
 	for dir in $(DIRS); do (cd $$dir && make clean || exit 1) || exit 1; done

--- a/server/plat/CMakeLists.txt
+++ b/server/plat/CMakeLists.txt
@@ -27,6 +27,12 @@ set (GDIAL_PLAT_DEPEND_LIBRARIES "${GLIB_LIBRARIES} ${GOBJECT_LIBRARIES}")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS} -std=c++11 -Wno-nonnull -DRT_PLATFORM_LINUX")
 
+option(DISABLE_SECURITY_TOKEN "Disable security token" OFF)
+
+if(DISABLE_SECURITY_TOKEN)
+  add_definitions(-DDISABLE_SECURITY_TOKEN)
+endif()
+
 #
 # Template that generates .pc file
 #
@@ -69,4 +75,8 @@ if(PLATFORM)
 endif()
 
 add_library(gdial-plat SHARED ${GDIAL_PLAT_LIB_SOURCE_FILES})
-target_link_Libraries(gdial-plat PRIVATE ${GLIB_LIBRARIES} ${GOBJECT_LIBRARIES} -lpthread -lWPEFrameworkCore -lWPEFrameworkDefinitions -lWPEFrameworkCOM -lWPEFrameworkPlugins -lWPEFrameworkSecurityUtil -lIARMBus -luuid)
+if(DISABLE_SECURITY_TOKEN)
+  target_link_Libraries(gdial-plat PRIVATE ${GLIB_LIBRARIES} ${GOBJECT_LIBRARIES} -lpthread -lWPEFrameworkCore -lWPEFrameworkDefinitions -lWPEFrameworkCOM -lWPEFrameworkPlugins -lIARMBus -luuid)
+else()
+  target_link_libraries(gdial-plat PRIVATE ${GLIB_LIBRARIES} ${GOBJECT_LIBRARIES} -lpthread -lWPEFrameworkCore -lWPEFrameworkDefinitions -lWPEFrameworkCOM -lWPEFrameworkPlugins -lWPEFrameworkSecurityUtil -lIARMBus -luuid)
+endif()

--- a/server/plat/gdial.cpp
+++ b/server/plat/gdial.cpp
@@ -32,7 +32,9 @@
 #include <json/JsonData_StateControl.h>
 #include <com/Ids.h>
 #include <curl/curl.h>
+#ifndef DISABLE_SECURITY_TOKEN
 #include <securityagent/SecurityTokenUtil.h>
+#endif
 #include "gdial-app.h"
 #include "gdial-plat-dev.h"
 #include "gdial-os-app.h"
@@ -572,21 +574,26 @@ std::string GetCurrentState() {
      std::string netflixState = "";
      Core::JSON::ArrayType<PluginHost::MetaData::Service> pluginResponse;
      Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T("127.0.0.1:9998")));
+     string sToken = "";
+     string query = "";
+#ifdef DISABLE_SECURITY_TOKEN
+    query = "token=" + sToken;
+#else
      unsigned char buffer[MAX_LENGTH] = {0};
 
      //Obtaining controller object
      if (NULL == controllerRemoteObject) {
          int ret = GetSecurityToken(MAX_LENGTH,buffer);
-         if(ret<0)
+         if(ret>0)
          {
-           controllerRemoteObject = new JSONRPC::LinkType<Core::JSON::IElement>(std::string());
-         } else {
-           string sToken = (char*)buffer;
-           string query = "token=" + sToken;
+           sToken = (char*)buffer;
+           query = "token=" + sToken;
            GDIAL_LOGINFO("Security token[%s] ",query.c_str());
-           controllerRemoteObject = new JSONRPC::LinkType<Core::JSON::IElement>(std::string(), false, query);
          }
      }
+#endif
+     controllerRemoteObject = new JSONRPC::LinkType<Core::JSON::IElement>(std::string(), false, query);
+
      std::string nfxstatus = "status@" + nfx_callsign;
      if(controllerRemoteObject->Get(1000, _T(nfxstatus), pluginResponse) == Core::ERROR_NONE)
      {


### PR DESCRIPTION
Reason for change: Added DISABLE_SECURITY_TOKEN Flag to disable the WPEFrameworkSecurity Token generation changes
Test Procedure: please referred from the ticket
Risks: Medium
Signed-off-by: Thamim Razith <ThamimRazith_AbbasAli@comcast.com>