### PR TITLE
RDKEMW-19912: Ignore System App to change PowerState request if SYSTEM_SLEEP_REQUEST_KEY not configured

### DIFF
--- a/server/plat/gdial.cpp
+++ b/server/plat/gdial.cpp
@@ -522,8 +522,13 @@ int gdial_os_application_start(const char *app_name, const char *payload, const 
         auto parsed_query{parse_query(query_string)};
         if (parsed_query["action"] == "sleep") {
             const char *system_key = getenv("SYSTEM_SLEEP_REQUEST_KEY");
-            if (system_key && parsed_query["key"] != system_key) {
-                GDIAL_LOGINFO("system app request to change device to sleep mode, key comparison failed: user provided '%s'", parsed_query["key"].c_str());
+            if ((NULL == system_key) || (system_key && parsed_query["key"] != system_key)) {
+				if (NULL == system_key) {
+					GDIAL_LOGINFO("SYSTEM_SLEEP_REQUEST_KEY is not configured, So ignoring system app request to change device to sleep mode");
+				}
+				else {
+					GDIAL_LOGINFO("system app request to change device to sleep mode, key comparison failed: user provided '%s'", parsed_query["key"].c_str());
+				}
                 GDIAL_LOGTRACE("Exiting ...");
                 return GDIAL_APP_ERROR_INTERNAL;
             }
@@ -534,8 +539,13 @@ int gdial_os_application_start(const char *app_name, const char *payload, const 
         }
         else if (parsed_query["action"] == "togglepower") {
             const char *system_key = getenv("SYSTEM_SLEEP_REQUEST_KEY");
-            if (system_key && parsed_query["key"] != system_key) {
-                GDIAL_LOGINFO("system app request to toggle the power state, key comparison failed: user provided '%s'", parsed_query["key"].c_str());
+            if ((NULL == system_key) || (system_key && parsed_query["key"] != system_key)) {
+				if (NULL == system_key) {
+					GDIAL_LOGINFO("SYSTEM_SLEEP_REQUEST_KEY is not configured, So ignoring system app request to toggle the power state");
+				}
+				else {
+					GDIAL_LOGINFO("system app request to toggle the power state, key comparison failed: user provided '%s'", parsed_query["key"].c_str());
+				}
                 GDIAL_LOGTRACE("Exiting ...");
                 return GDIAL_APP_ERROR_INTERNAL;
             }

--- a/tests/L1Tests/plat/test_gdialCpp.cpp
+++ b/tests/L1Tests/plat/test_gdialCpp.cpp
@@ -310,8 +310,9 @@ TEST_F(GDialCppTest, OsUpdateManufacturerAndModel_AfterInitReturnNone)
 TEST_F(GDialCppTest, OsApplicationStart_SystemSleepTriggersPowerOff)
 {
     ASSERT_TRUE(gdial_cpp_test_init(ctx));
+    setenv("SYSTEM_SLEEP_REQUEST_KEY", "testkey", 1);
     int instance_id = 0;
-    EXPECT_EQ(gdial_cpp_test_os_application_start("system", "", "action=sleep", "", &instance_id), GDIAL_APP_ERROR_NONE);
+    EXPECT_EQ(gdial_cpp_test_os_application_start("system", "", "action=sleep&key=testkey", "", &instance_id), GDIAL_APP_ERROR_NONE);
     EXPECT_EQ(g_power_cb_calls, 1);
     EXPECT_EQ(g_last_power_state, "STANDBY");
 }
@@ -319,8 +320,9 @@ TEST_F(GDialCppTest, OsApplicationStart_SystemSleepTriggersPowerOff)
 TEST_F(GDialCppTest, OsApplicationStart_SystemTogglePowerTriggersToggle)
 {
     ASSERT_TRUE(gdial_cpp_test_init(ctx));
+    setenv("SYSTEM_SLEEP_REQUEST_KEY", "testkey", 1);
     int instance_id = 0;
-    EXPECT_EQ(gdial_cpp_test_os_application_start("system", "", "action=togglepower", "", &instance_id), GDIAL_APP_ERROR_NONE);
+    EXPECT_EQ(gdial_cpp_test_os_application_start("system", "", "action=togglepower&key=testkey", "", &instance_id), GDIAL_APP_ERROR_NONE);
     EXPECT_EQ(g_power_cb_calls, 1);
     EXPECT_EQ(g_last_power_state, "TOGGLE");
 }
@@ -330,6 +332,26 @@ TEST_F(GDialCppTest, OsApplicationState_SystemReturnsHide)
     GDialAppState state = GDIAL_APP_STATE_MAX;
     EXPECT_EQ(gdial_cpp_test_os_application_state("system", 1, &state), GDIAL_APP_ERROR_NONE);
     EXPECT_EQ(state, GDIAL_APP_STATE_HIDE);
+}
+
+TEST_F(GDialCppTest, OsApplicationStart_SystemSleepWithNullKeyReturnsInternal)
+{
+    ASSERT_TRUE(gdial_cpp_test_init(ctx));
+    /* SYSTEM_SLEEP_REQUEST_KEY is unset (NULL) — request must be rejected. */
+    int instance_id = 0;
+    EXPECT_EQ(gdial_cpp_test_os_application_start("system", "", "action=sleep", "", &instance_id),
+              GDIAL_APP_ERROR_INTERNAL);
+    EXPECT_EQ(g_power_cb_calls, 0);
+}
+
+TEST_F(GDialCppTest, OsApplicationStart_SystemTogglePowerWithNullKeyReturnsInternal)
+{
+    ASSERT_TRUE(gdial_cpp_test_init(ctx));
+    /* SYSTEM_SLEEP_REQUEST_KEY is unset (NULL) — request must be rejected. */
+    int instance_id = 0;
+    EXPECT_EQ(gdial_cpp_test_os_application_start("system", "", "action=togglepower", "", &instance_id),
+              GDIAL_APP_ERROR_INTERNAL);
+    EXPECT_EQ(g_power_cb_calls, 0);
 }
 
 TEST_F(GDialCppTest, OsApplicationStart_SystemSleepWithWrongKeyReturnsInternal)


### PR DESCRIPTION
RDKEMW-19912: Ignore System App to change PowerState request if SYSTEM_SLEEP_REQUEST_KEY not configured

Signed-off-by: yuvaramachandran_gurusamy [yuvaramachandran_gurusamy@comcast.com]